### PR TITLE
Updating .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,16 @@
 *.exe
 *.out
 *.app
+
+# Eclipse Workspace Files
+*.cproject
+*.project
+
+# VIM swap files
+*.swp
+
+# ROS workspace files and directories (contents change on catkin_make)
+ros_workspace/.catkin_workspace
+ros_workspace/src/CMakeLists.txt
+ros_workspace/build/
+ros_workspace/devel/


### PR DESCRIPTION
This commit updates this repository's .gitignore file so Eclipse's workspace files and the ROS workspace contents that change on catkin_make are ignored.