### PR TITLE
Removing URDF Friction Coefficients

### DIFF
--- a/ros_workspace/src/robomagellan_2024_description/urdf/robomagellan_2024.urdf.xacro
+++ b/ros_workspace/src/robomagellan_2024_description/urdf/robomagellan_2024.urdf.xacro
@@ -105,8 +105,6 @@
       properties.
     -->
     <gazebo reference="${prefix}_${suffix}_wheel">
-      <mu1 value="200.0"/>
-      <mu2 value="100.0"/>
       <kp value="10000000.0"/>
       <kd value="1.0"/>
       <material>Gazebo/Black</material>


### PR DESCRIPTION
The friction coefficients are not needed because they were incorrect for the robot.