### PR TITLE
Fixing Namespacing for RPI Motors Topics/Services and Send Lin/Ang Commands

### DIFF
--- a/prototyping_code/python_testing_grounds/ramp_motors.py
+++ b/prototyping_code/python_testing_grounds/ramp_motors.py
@@ -9,9 +9,9 @@ def main():
     rospy.init_node('step_motors')
 
     # Wait for RPI motors service to be available
-    rospy.wait_for_service('/rpi_motor_commands')
+    rospy.wait_for_service('/rpi_motors/rpi_motor_commands')
 
-    motor_srv = rospy.ServiceProxy('/rpi_motor_commands', RPIMotors)
+    motor_srv = rospy.ServiceProxy('/rpi_motors/rpi_motor_commands', RPIMotors)
 
     motor_cmd = RPIMotorsRequest()
     #motor_cmd.left_desired_velocity = 0.0

--- a/prototyping_code/python_testing_grounds/step_motors.py
+++ b/prototyping_code/python_testing_grounds/step_motors.py
@@ -9,9 +9,9 @@ def main():
     rospy.init_node('step_motors')
 
     # Wait for RPI motors service to be available
-    rospy.wait_for_service('/rpi_motor_commands')
+    rospy.wait_for_service('/rpi_motors/rpi_motor_commands')
 
-    motor_srv = rospy.ServiceProxy('/rpi_motor_commands', RPIMotors)
+    motor_srv = rospy.ServiceProxy('/rpi_motors/rpi_motor_commands', RPIMotors)
 
     motor_cmd = RPIMotorsRequest()
     motor_cmd.left_desired_velocity = 0.0

--- a/ros_workspace/src/rpi_motors/src/rpi_motors_node.py
+++ b/ros_workspace/src/rpi_motors/src/rpi_motors_node.py
@@ -69,13 +69,13 @@ class RPIMotorsControl:
         rospy.Subscriber('/odometry/current_velocities', Velocities, self.HandleVelocityMsg)
 
         # Start service to send motor commands (left/right velocities)
-        motor_service = rospy.Service('rpi_motor_commands', RPIMotors, self.HandleMotorCommand)
+        motor_service = rospy.Service('/rpi_motors/rpi_motor_commands', RPIMotors, self.HandleMotorCommand)
 
         # Service to send motor commands (linear/angular velocities)
-        lin_ang_motor_service = rospy.Service('rpi_motor_commands_lin_ang', RPIMotorsLinAng, self.HandleLinAngMotorCommand)
+        lin_ang_motor_service = rospy.Service('/rpi_motors/rpi_motor_commands_lin_ang', RPIMotorsLinAng, self.HandleLinAngMotorCommand)
 
         # Publisher to publish desired motor velocities
-        self._desired_vel_pub = rospy.Publisher('rpi_motor_desired_velocities', Velocities, queue_size=10)
+        self._desired_vel_pub = rospy.Publisher('/rpi_motors/rpi_motor_desired_velocities', Velocities, queue_size=10)
 
         # Setup dynamic reconfigure server
         self._reconfigure_server = Server(DynamicParamConfig, callback=self.DynamicReconfigureCallback)

--- a/ros_workspace/src/utils/src/send_lin_ang_commands.cpp
+++ b/ros_workspace/src/utils/src/send_lin_ang_commands.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[]) {
 
   ros::NodeHandle nh;
   client = nh.serviceClient<rpi_motors::RPIMotorsLinAng>(
-      "rpi_motor_commands_lin_ang");
+      "/rpi_motors/rpi_motor_commands_lin_ang");
 
   // Attach SIGINT signal handler
   signal(SIGINT, ShutdownSignalHandler);
@@ -51,12 +51,15 @@ int main(int argc, char *argv[]) {
     double lin_vel = 0.0, ang_vel = 0.0;
     std::cin >> lin_vel >> ang_vel;
 
-    std::cout << "Sending linear: " << lin_vel << " m/s; angular: " << ang_vel
-      << " rad/s" << std::endl;
+    next_command.request.linear_velocity = lin_vel;
+    next_command.request.angular_velocity = ang_vel;
 
     if (!client.call(next_command)) {
       std::cerr << "ERROR: failed to send command to RPI Motors node" <<
         std::endl;
+    } else {
+      std::cout << "Successfully sent linear: " << lin_vel << " m/s; angular: "
+        << ang_vel << " rad/s" << std::endl;
     }
   }
   return 0;


### PR DESCRIPTION
Properly namespacing all RPI Motors node topics/services and fixing a bug where the send_lin_ang_command was not setting the desired velocities.