### PR TITLE
Initial robomagellan_bringup Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # robogames_2024
-RoboMagellan 2024 Competition
+
+This repository contains the code used for a RoboMagellan outdoor navigation
+robotics competition.
+
+## Dependencies
+
+The robot is running Ubuntu 24.04 and needs ROS 2 Jazzy installed.
+
+## Running the Robot
+
+The `robomagellan_bringup` package contains the launch files used to start the
+robot for a RoboMagellan competition.  Please run:
+`ros2 launch robomagellan_bringup competition.launch.py` to start the robot.

--- a/ros2_ws/src/robomagellan_bringup/CMakeLists.txt
+++ b/ros2_ws/src/robomagellan_bringup/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.8)
+project(robomagellan_bringup)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/ros2_ws/src/robomagellan_bringup/launch/competition.launch.py
+++ b/ros2_ws/src/robomagellan_bringup/launch/competition.launch.py
@@ -1,0 +1,11 @@
+'''
+competition.launch.py
+
+Launch file for the real robot to be used during a RoboMagellan competition.
+'''
+from launch import LaunchDescription
+
+# "main" function for launch files
+def generate_launch_description():
+    return LaunchDescription([
+    ])

--- a/ros2_ws/src/robomagellan_bringup/package.xml
+++ b/ros2_ws/src/robomagellan_bringup/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>robomagellan_bringup</name>
+  <version>0.1.0</version>
+  <description>Launch files for the RoboMagellan Competition</description>
+  <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This commit adds in the initial `robomagellan_bringup` package, which contains the launch files used for a RoboMagellan competition.