### PR TITLE
ros2_control - Initial Differential Drive Controller Integration

### DIFF
--- a/ros2_ws/src/robomagellan_bringup/README.md
+++ b/ros2_ws/src/robomagellan_bringup/README.md
@@ -1,0 +1,16 @@
+# robomagellan_bringup
+
+This package contains the launch files to start either the real robot or a
+simulated robot.
+
+## Launch Files
+
+The following is a list of the Python launch files and their purpose:
+
+1. `competition.launch.py` - Real robot startup
+2. `sim.launch.py` - Gazebo/simulated robot startup
+
+## Changelog
+`0.2.0` - Initial `sim.launch.py`
+
+`0.1.0` - Initial package and `competition.launch.py`

--- a/ros2_ws/src/robomagellan_bringup/launch/sim.launch.py
+++ b/ros2_ws/src/robomagellan_bringup/launch/sim.launch.py
@@ -1,0 +1,34 @@
+"""
+sim.launch.py
+
+Starts Gazebo and spawns the simulated robot.
+"""
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+
+import os
+
+def generate_launch_description():
+    # Spawn Gazebo and the simulated robot
+    gazebo = IncludeLaunchDescription(
+        os.path.join(
+            get_package_share_directory("robomagellan_description"),
+            "launch",
+            "gazebo.launch.py"
+        )
+    )
+
+    # Start the differential drive controller
+    controller = IncludeLaunchDescription(
+        os.path.join(
+            get_package_share_directory("robomagellan_controller"),
+            "launch",
+            "controller.launch.py"
+        )
+    )
+
+    return LaunchDescription([
+        gazebo,
+        controller
+    ])

--- a/ros2_ws/src/robomagellan_bringup/package.xml
+++ b/ros2_ws/src/robomagellan_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robomagellan_bringup</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Launch files for the RoboMagellan Competition</description>
   <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
   <license>Apache 2.0</license>

--- a/ros2_ws/src/robomagellan_controller/CMakeLists.txt
+++ b/ros2_ws/src/robomagellan_controller/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5)
+project(robomagellan_controller)
+
+find_package(ament_cmake REQUIRED)
+
+# Install directories
+install(
+  DIRECTORY launch config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/ros2_ws/src/robomagellan_controller/README.md
+++ b/ros2_ws/src/robomagellan_controller/README.md
@@ -1,0 +1,16 @@
+# robomagellan_controller
+
+This package contains the configuration and launch files used to spawn the stock
+`ros2_controls` differential drive controller.
+
+## config files
+`robomagellan_controllers.yaml` contains the `ros2_control` settings for the
+differential drive controller.  Once the speed/acceleration limits are
+determined change them here.
+
+## launch files
+`controller.launch.py` loads the differential drive controller using the
+`controller_manager`.
+
+## Changelog
+`0.1.0` - Initial package

--- a/ros2_ws/src/robomagellan_controller/config/robomagellan_controllers.yaml
+++ b/ros2_ws/src/robomagellan_controller/config/robomagellan_controllers.yaml
@@ -1,0 +1,88 @@
+# robomagellan_controllers.yaml
+#
+# ros2_control parameters for the differential drive controller
+
+# List of the controllers to use
+controller_manager:
+  ros__parameters:
+    # Rate at which controllers are run (Hz)
+    update_rate: 100
+
+    # Using stock differential drive controller
+    robomagellan_controller:
+      type: diff_drive_controller/DiffDriveController
+
+    # Reads the controller's state interfaces and broadcasts them on
+    # /joint_states
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+# Differential drive controller config params
+robomagellan_controller:
+  ros__parameters:
+    # Stock differential drive controller; no need to write one up
+    type: diff_drive_controller/DiffDriveController
+
+    # Use timestamped velocity
+    use_stamped_vel: true
+
+    # Names of the left/right wheel joints.  The rear wheels are connected by
+    # belts; in the URDF the rear wheels mimic the front wheels.
+    left_wheel_names: ['left_front_joint']
+    right_wheel_names: ['right_front_joint']
+
+    # Odometry publish rate (Hz)
+    publish_rate: 50.0
+
+    # Covariances.  Only care about (x, y, yaw)
+    pose_covariance_diagonal: [0.001, 0.001, 1.0e-3, 1.0e-3, 1.0e-3, 0.01]
+    twist_covariance_diagonal: [0.001, 0.001, 1.0e-3, 1.0e-3, 1.0e-3, 0.01]
+
+    # Distance between the left and right wheels (m).  22.5 inches = 0.5715 m
+    wheel_separation: 0.5715
+
+    # Wheel radius (m)
+    wheel_radius: 0.0762
+
+    # Multipliers.  Not used so keep them at 1.0
+    wheel_separation_multiplier: 1.0
+    left_wheel_radius_multiplier: 1.0
+    right_wheel_radius_multiplier: 1.0
+
+    # Time (s) to wait for velocity commands before zeroing velocities
+    cmd_vel_timeout: 0.5
+
+    # Base frame id.  Use base_footprint since this is a planar robot
+    base_frame_id: base_footprint
+
+    # Publish limited velocity
+    publish_limited_velocity: true
+
+    # Publish wheel data
+    publish_wheel_data: true
+
+    # Publish TF transforms
+    enable_odom_tf: true
+
+    # Velocity/acceleration limits.  If a minimum limit is NOT specified
+    # default to -(maximum limit).  Linear velocity limits are in m/s;
+    # linear acceleration limits are in m/s^2.  Angular velocity limits are
+    # in rad/s; angular acceleration limits are in rad/s^2.
+    linear:
+      x:
+        has_velocity_limits: true
+        max_velocity: 0.7
+        min_velocity: -0.7
+        has_acceleration_limits: true
+        max_acceleration: 0.7
+        min_acceleration: -0.7
+        has_jerk_limits: false
+    angular:
+      z:
+        has_velocity_limits: true
+        max_velocity: 8.5
+        min_velocity: -8.5
+        has_acceleration_limits: true
+        max_acceleration: 5.0
+        min_acceleration: -5.0
+        has_jerk_limits: false

--- a/ros2_ws/src/robomagellan_controller/launch/controller.launch.py
+++ b/ros2_ws/src/robomagellan_controller/launch/controller.launch.py
@@ -1,0 +1,35 @@
+"""
+controller.launch.py
+
+Spawns the differential drive controller.
+"""
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    # Joint state broadcaster reads the states from all state interfaces and
+    # publishes states on /joint_states
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "joint_state_broadcaster",
+            "--controller-manager",
+            "/controller_manager"
+        ]
+    )
+
+    # Start the differential drive controller
+    wheel_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["robomagellan_controller",
+                   "--controller-manager",
+                   "/controller_manager"
+        ]
+    )
+
+    return LaunchDescription([
+        joint_state_broadcaster_spawner,
+        wheel_controller_spawner
+    ])

--- a/ros2_ws/src/robomagellan_controller/package.xml
+++ b/ros2_ws/src/robomagellan_controller/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>robomagellan_controller</name>
+  <version>0.1.0</version>
+  <description>Config params and launch files for the differential drive controller</description>
+  <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2_ws/src/robomagellan_description/README.md
+++ b/ros2_ws/src/robomagellan_description/README.md
@@ -21,6 +21,8 @@ The following is a list of the Python launch files and their purpose:
 2. `gazebo.launch.py`: Starts the Gazebo simulation and spawns the robot.
 
 ## Changelog
+`0.3.0` - Adding `ros2_control` and `gazebo` plugins to URDFs.
+
 `0.2.0` - Updating `robomagellan.urdf.xacro` to remove the `chassis` link,
 correct the `base_link` -> `base_footprint` transform, and fixed the wheels'
 frame orientations.  Added `display.launch.py` and `gazebo.launch.py` to work

--- a/ros2_ws/src/robomagellan_description/package.xml
+++ b/ros2_ws/src/robomagellan_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robomagellan_description</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Contains the URDF robot description</description>
   <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
   <license>Apache 2.0</license>

--- a/ros2_ws/src/robomagellan_description/urdf/gazebo.xacro
+++ b/ros2_ws/src/robomagellan_description/urdf/gazebo.xacro
@@ -1,24 +1,50 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!-- Wheel links -->
+  <gazebo reference="left_front_wheel">
+    <mu1>1000000000000000.0</mu1>
+    <mu2>1000000000000000.0</mu2>
+    <kp>1000000000000.0</kp>
+    <kd>10.0</kd>
+    <minDepth>0.001</minDepth>
+    <maxVel>0.1</maxVel>
+    <fdir1>1 0 0</fdir1>
+  </gazebo>
+
+  <gazebo reference="right_front_wheel">
+    <mu1>1000000000000000.0</mu1>
+    <mu2>1000000000000000.0</mu2>
+    <kp>1000000000000.0</kp>
+    <kd>10.0</kd>
+    <minDepth>0.001</minDepth>
+    <maxVel>0.1</maxVel>
+    <fdir1>1 0 0</fdir1>
+  </gazebo>
+
+  <gazebo reference="left_rear_wheel">
+    <mu1>1000000000000000.0</mu1>
+    <mu2>1000000000000000.0</mu2>
+    <kp>1000000000000.0</kp>
+    <kd>10.0</kd>
+    <minDepth>0.001</minDepth>
+    <maxVel>0.1</maxVel>
+    <fdir1>1 0 0</fdir1>
+  </gazebo>
+
+  <gazebo reference="right_rear_wheel">
+    <mu1>1000000000000000.0</mu1>
+    <mu2>1000000000000000.0</mu2>
+    <kp>1000000000000.0</kp>
+    <kd>10.0</kd>
+    <minDepth>0.001</minDepth>
+    <maxVel>0.1</maxVel>
+    <fdir1>1 0 0</fdir1>
+  </gazebo>
+
+  <!-- ros2_control Gazebo plugins -->
   <gazebo>
-    <plugin name='diff_drive' filename='libgazebo_ros_diff_drive.so'>
-      <!-- Wheel Information -->
-      <left_joint>left_front_joint</left_joint>
-      <right_joint>right_front_joint</right_joint>
-      <wheel_separation>0.5715</wheel_separation>
-      <wheel_diameter>0.1524</wheel_diameter>
-
-      <!-- Limits -->
-      <max_wheel_torque>200</max_wheel_torque>
-      <max_wheel_acceleration>10.0</max_wheel_acceleration>
-
-      <!-- Odometry Output -->
-      <odometry_frame>odom</odometry_frame>
-      <robot_base_frame>base_link</robot_base_frame>
-
-      <publish_odom>true</publish_odom>
-      <publish_odom_tf>true</publish_odom_tf>
-      <publish_wheel_tf>true</publish_wheel_tf>
+    <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+      <parameters>$(find robomagellan_controller)/config/robomagellan_controllers.yaml</parameters>
     </plugin>
   </gazebo>
 </robot>

--- a/ros2_ws/src/robomagellan_description/urdf/robomagellan.urdf.xacro
+++ b/ros2_ws/src/robomagellan_description/urdf/robomagellan.urdf.xacro
@@ -5,10 +5,10 @@
   <xacro:arg name="is_sim" default="true"/>
 
   <!-- Include Gazebo parameters -->
- <!-- <xacro:include filename="$(find robomagellan_description)/urdf/gazebo.xacro"/> -->
+  <xacro:include filename="$(find robomagellan_description)/urdf/gazebo.xacro"/>
 
-  <!-- Include ros2_contol plugins -->
- <!-- <xacro:include filename="$(find robomagellan_description)/urdf/ros2_control.xacro"/> -->
+  <!-- Include ros2_contol plugins/interfaces -->
+  <xacro:include filename="$(find robomagellan_description)/urdf/ros2_control.xacro"/>
 
   <!-- Inertial Macros -->
   <xacro:macro name="inertial_box" params="mass x y z">

--- a/ros2_ws/src/robomagellan_description/urdf/ros2_control.xacro
+++ b/ros2_ws/src/robomagellan_description/urdf/ros2_control.xacro
@@ -1,5 +1,39 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="robot">
   <ros2_control name="RobotSystem" type="system">
+    <!-- ros2_control plugin for Gazebo -->
+    <xacro:if value="$(arg is_sim)">
+      <hardware>
+        <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      </hardware>
+    </xacro:if>
+
+    <!-- ros2_control plugin for the real robot -->
+    <xacro:unless value="$(arg is_sim)">
+      <hardware>
+        <plugin>robomagellan_firmware/RobomagellanInterface</plugin>
+        <param name="port">/dev/ttyUSB0</param>
+      </hardware>
+    </xacro:unless>
+
+    <!-- ros2_control common interfaces -->
+    <joint name="left_front_joint">
+      <command_interface name="velocity">
+        <param name="min">-1</param>
+        <param name="max">1</param>
+      </command_interface>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+
+    <joint name="right_front_joint">
+      <command_interface name="velocity">
+        <param name="min">-1</param>
+        <param name="max">1</param>
+      </command_interface>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+  </ros2_control>
 </robot>
 


### PR DESCRIPTION
This commit adds in the launch & config files to load the stock differential drive controller using the `ros2_control` `controller_manager`.

This is tested using `robomagellan_bringup` `sim.launch.py`.