### PR TITLE
Adding Joystick Teleoperation to Simulation

### DIFF
--- a/ros2_ws/src/robomagellan_bringup/README.md
+++ b/ros2_ws/src/robomagellan_bringup/README.md
@@ -11,6 +11,9 @@ The following is a list of the Python launch files and their purpose:
 2. `sim.launch.py` - Gazebo/simulated robot startup
 
 ## Changelog
+`0.3.0` - Spawning `joy`/`joy_teleop` nodes for Xbox controller simulation
+control
+
 `0.2.0` - Initial `sim.launch.py`
 
 `0.1.0` - Initial package and `competition.launch.py`

--- a/ros2_ws/src/robomagellan_bringup/launch/sim.launch.py
+++ b/ros2_ws/src/robomagellan_bringup/launch/sim.launch.py
@@ -28,7 +28,20 @@ def generate_launch_description():
         )
     )
 
+    # Start the joystick teleop nodes.  TODO: Use keyboard teleop node instead?
+    joystick = IncludeLaunchDescription(
+        os.path.join(
+            get_package_share_directory("robomagellan_controller"),
+            "launch",
+            "joystick_teleop.launch.py"
+        ),
+        launch_arguments={
+            "use_sim_time": "True"
+        }.items()
+    )
+
     return LaunchDescription([
         gazebo,
-        controller
+        controller,
+        joystick
     ])

--- a/ros2_ws/src/robomagellan_bringup/package.xml
+++ b/ros2_ws/src/robomagellan_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robomagellan_bringup</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Launch files for the RoboMagellan Competition</description>
   <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
   <license>Apache 2.0</license>

--- a/ros2_ws/src/robomagellan_controller/README.md
+++ b/ros2_ws/src/robomagellan_controller/README.md
@@ -13,4 +13,6 @@ determined change them here.
 `controller_manager`.
 
 ## Changelog
+`0.2.0` - `joy`/`joy_teleop` nodes and configs to connect to an Xbox controller
+
 `0.1.0` - Initial package

--- a/ros2_ws/src/robomagellan_controller/config/joy_config.yaml
+++ b/ros2_ws/src/robomagellan_controller/config/joy_config.yaml
@@ -1,0 +1,26 @@
+# joy_config.yaml
+#
+# Parameters for the joy node that reads joystick values from the specified
+# joystick and publishes them to the /joy topic.  Refer to
+# https://docs.ros.org/en/jazzy/p/joy/ for additional parameter information.
+joystick:
+  ros__parameters:
+    # The joystick ID can be seen by running
+    # "ros2 run joy joy_enumerate_devices"
+    device_id: 0
+
+    # Name of the joystick.  Needed if multiple joysticks are connected
+    device_name: ""
+
+    # Device deadzone is the percentage of the joystick that needs to be moved
+    # to be considered off-center.
+    deadzone: 0.5
+
+    # Rate (Hz) that the joystick will continue sending the same readings
+    autorepeat_rate: 20.0
+
+    # If true, button releases do nothing
+    sticky_buttons: false
+
+    # Time (ms) to wait after an axis event before publishing a message
+    coalesce_interval_ms: 1

--- a/ros2_ws/src/robomagellan_controller/config/joy_teleop.yaml
+++ b/ros2_ws/src/robomagellan_controller/config/joy_teleop.yaml
@@ -1,0 +1,41 @@
+# joy_teleop.yaml
+#
+# Parameters for the node that subscribes to the /joy topic and maps these
+# joystick inputs to the robot's velocity inputs.
+joy_teleop:
+  ros__parameters:
+    move:
+      # The differential drive controller receives desired input velocities
+      # (linear x + angular z) on the /robomagellan_controller/cmd_vel topic of
+      # type geometry_msgs/msg/TwistStamped
+
+      # Type of ROS interface to use (topic/service/action)
+      type: topic
+
+      # The type of the specified interface
+      interface_type: geometry_msgs/msg/TwistStamped
+
+      # Name of the input interface (either topic_name/service_name/action_name)
+      topic_name: robomagellan_controller/cmd_vel
+
+      # List of buttons to be held down for the command to be active.  This is
+      # not optional, so for the XBOX controller button B is button 1
+      # (0-indexed)
+      deadman_buttons: [1]
+
+      # Joystick axis mappings to the TwistStamped message.  We only need a
+      # forward input for the linear x velocity and an angular input for the
+      # angular z velocity.
+      #
+      # For the XBOX controller inspection of the /joy topic shows that for the
+      # left joystick forward/backwards is axis 1 (0-indexed) and left/right is
+      # axis 0 (0-indexed)
+      axis_mappings:
+        twist-linear-x:
+          axis: 1
+          scale: 1.0
+          offset: 0.0
+        twist-angular-z:
+          axis: 0
+          scale: 8.0
+          offset: 0.0

--- a/ros2_ws/src/robomagellan_controller/launch/joystick_teleop.launch.py
+++ b/ros2_ws/src/robomagellan_controller/launch/joystick_teleop.launch.py
@@ -1,0 +1,51 @@
+"""
+joystick_teleop.launch.py
+
+Launches the nodes to enable sending robot velocity commands from a joystick
+(USB or Bluetooth).
+"""
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+import os
+
+def generate_launch_description():
+    # Use simulated or real time?
+    use_sim_time_arg = DeclareLaunchArgument(name="use_sim_time",
+                                             default_value="True",
+                                             description="Use simulated time?"
+    )
+
+    # The joy node connects to the joystick at the specified interface and
+    # publishes the joystick commands to the /joy topic.
+    joy_node = Node(
+        package="joy",
+        executable="joy_node",
+        name="joystick",
+        parameters=[
+            os.path.join(get_package_share_directory("robomagellan_controller"),
+                         "config", "joy_config.yaml"),
+            {"use_sim_time": LaunchConfiguration("use_sim_time")}
+        ]
+    )
+
+    # The joy_teleop node subscribes to the /joy topic and maps those values to
+    # the robot's velocity inputs.
+    joy_teleop = Node(
+        package="joy_teleop",
+        executable="joy_teleop",
+        parameters=[
+            os.path.join(get_package_share_directory("robomagellan_controller"),
+                         "config", "joy_teleop.yaml"),
+            {"use_sim_time": LaunchConfiguration("use_sim_time")}
+        ]
+    )
+
+    return LaunchDescription([
+        use_sim_time_arg,
+        joy_node,
+        joy_teleop
+    ])

--- a/ros2_ws/src/robomagellan_controller/package.xml
+++ b/ros2_ws/src/robomagellan_controller/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>robomagellan_controller</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Config params and launch files for the differential drive controller</description>
   <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
   <license>Apache 2.0</license>


### PR DESCRIPTION
This commit adds the `joy`/`joy_teleop` nodes to the `sim.launch.py`. You can now drive the simulated robot using an Xbox controller.