### PR TITLE
robomagellan_description - Removed mimic_wheel Macro

### DIFF
--- a/ros2_ws/src/robomagellan_description/README.md
+++ b/ros2_ws/src/robomagellan_description/README.md
@@ -21,6 +21,9 @@ The following is a list of the Python launch files and their purpose:
 2. `gazebo.launch.py`: Starts the Gazebo simulation and spawns the robot.
 
 ## Changelog
+`0.7.0` - `robomagellan.urdf.xacro` has removed the `mimic_wheel` macro and
+condensed it with the `wheel` macro and an `xacro:if`.
+
 `0.6.0` - `robomagellan.urdf.xacro` has corrected wheel inertial matrices and
 wheel collision layers are now spherical rather than cylindrical.
 

--- a/ros2_ws/src/robomagellan_description/package.xml
+++ b/ros2_ws/src/robomagellan_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robomagellan_description</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>Contains the URDF robot description</description>
   <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
   <license>Apache 2.0</license>

--- a/ros2_ws/src/robomagellan_description/urdf/robomagellan.urdf.xacro
+++ b/ros2_ws/src/robomagellan_description/urdf/robomagellan.urdf.xacro
@@ -101,7 +101,7 @@
   </xacro:macro>
 
   <!-- Macro to create the wheels -->
-  <xacro:macro name="wheel" params="prefix suffix reflectx reflecty">
+  <xacro:macro name="wheel" params="prefix suffix reflectx reflecty mimic_wheel">
     <link name="${prefix}_${suffix}_wheel">
       <xacro:inertial_cylinder mass="${wheel_mass}" height="${wheel_width}" radius="${wheel_radius}"/>
       <visual>
@@ -126,38 +126,13 @@
       <parent link="base_link"/>
       <child link="${prefix}_${suffix}_wheel"/>
       <axis xyz="0 1 0"/>
+
+      <!-- Is this a mimic wheel? -->
+      <xacro:if value="${mimic_wheel}">
+        <mimic joint="${prefix}_front_joint" multiplier="1.0" offset="0.0"/>
+      </xacro:if>
     </joint>
   </xacro:macro>
-
-  <xacro:macro name="mimic_wheel" params="prefix suffix reflectx reflecty">
-    <link name="${prefix}_${suffix}_wheel">
-      <xacro:inertial_cylinder mass="${wheel_mass}" height="${wheel_width}" radius="${wheel_radius}"/>
-      <visual>
-        <origin xyz="0 0 0" rpy="${-reflecty*pi/2} 0 0"/>
-        <geometry>
-          <cylinder length="${wheel_width}" radius="${wheel_radius}"/>
-        </geometry>
-       <material name="black"/>
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="${-reflecty*pi/2} 0 0"/>
-        <!-- Use a sphere for collisions to have one ground contact point -->
-        <geometry>
-          <sphere radius="${wheel_radius}"/>
-        </geometry>
-      </collision>
-    </link>
-
-    <!-- Joint connecting this wheel to the base_link -->
-    <joint name="${prefix}_${suffix}_joint" type="continuous">
-      <origin xyz="${reflectx*wheel_x_offset} ${reflecty*wheel_y_offset} 0" rpy="0 0 0"/>
-      <parent link="base_link"/>
-      <child link="${prefix}_${suffix}_wheel"/>
-      <axis xyz="0 1 0"/>
-      <mimic joint="${prefix}_front_joint" multiplier="1.0" offset="0.0"/>
-    </joint>
-  </xacro:macro>
-
 
   <material name="black">
     <color rgba="0 0 0 1"/>
@@ -200,9 +175,9 @@
   </joint>
 
   <!-- Wheels -->
-  <xacro:wheel prefix="left" suffix="front" reflectx="1" reflecty="1"/>
-  <xacro:mimic_wheel prefix="left" suffix="rear" reflectx="-1" reflecty="1"/>
+  <xacro:wheel prefix="left" suffix="front" reflectx="1" reflecty="1" mimic_wheel="false"/>
+  <xacro:wheel prefix="left" suffix="rear" reflectx="-1" reflecty="1" mimic_wheel="true"/>
 
-  <xacro:wheel prefix="right" suffix="front" reflectx="1" reflecty="-1"/>
-  <xacro:mimic_wheel prefix="right" suffix="rear" reflectx="-1" reflecty="-1"/>
+  <xacro:wheel prefix="right" suffix="front" reflectx="1" reflecty="-1" mimic_wheel="false"/>
+  <xacro:wheel prefix="right" suffix="rear" reflectx="-1" reflecty="-1" mimic_wheel="true"/>
 </robot>


### PR DESCRIPTION
This commit removes the `mimic_wheel` macro and replaces it with an additional `mimic_wheel` parameter to the `wheel` macro.