### PR TITLE
robomagellan_controller - Removing Deprecated Jerk Flag

### DIFF
--- a/ros2_ws/src/robomagellan_controller/README.md
+++ b/ros2_ws/src/robomagellan_controller/README.md
@@ -13,6 +13,8 @@ determined change them here.
 `controller_manager`.
 
 ## Changelog
+`0.3.0` - Removed deprecated `diff_drive_controller` `has_jerk_limits`
+
 `0.2.0` - `joy`/`joy_teleop` nodes and configs to connect to an Xbox controller
 
 `0.1.0` - Initial package

--- a/ros2_ws/src/robomagellan_controller/config/robomagellan_controllers.yaml
+++ b/ros2_ws/src/robomagellan_controller/config/robomagellan_controllers.yaml
@@ -76,7 +76,6 @@ robomagellan_controller:
         has_acceleration_limits: true
         max_acceleration: 0.7
         min_acceleration: -0.7
-        has_jerk_limits: false
     angular:
       z:
         has_velocity_limits: true
@@ -85,4 +84,3 @@ robomagellan_controller:
         has_acceleration_limits: true
         max_acceleration: 5.0
         min_acceleration: -5.0
-        has_jerk_limits: false

--- a/ros2_ws/src/robomagellan_controller/package.xml
+++ b/ros2_ws/src/robomagellan_controller/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>robomagellan_controller</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Config params and launch files for the differential drive controller</description>
   <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
   <license>Apache 2.0</license>


### PR DESCRIPTION
This commit removes the `has_jerk_limits` flags since the `diff_drive_controller` deprecated these flags.  Instead set the jerk limits to `NaN`.