### PR TITLE
udev_rules - Adding Arduino udev Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ robotics competition.
 
 The robot is running Ubuntu 24.04 and needs ROS 2 Jazzy installed.
 
+## New Robot Installation Steps
+
+1) Install Ubuntu 24.04 (Noble) and ROS 2 Jazzy onto a Raspberry Pi 5
+
+2) On an Arduino Mega flash in the Arduino code `robomagellan_2024.ino` inside
+the `arduino_code` directory.
+
+3) Copy the `99-arduino.rules` from the `udev_rules` directory into
+`/etc/udev/rules.d` so the Arduino Mega will be associated with the device file
+`/dev/arduino`.  Be sure to call `sudo udevadm control --reload-rules && sudo
+udevadm trigger` to apply this rule.
+
+4) Build the `ros2` workspace by executing `colcon build` inside
+`robogames_2024/ros2_ws`.
+
 ## Running the Robot
 
 The `robomagellan_bringup` package contains the launch files used to start the

--- a/udev_rules/99-arduino.rules
+++ b/udev_rules/99-arduino.rules
@@ -1,0 +1,8 @@
+# 99-arduino.rules
+#
+# udev rules file for assigning an Arduino Mega to device file /dev/arduino
+#
+# Arduino Mega has ID 2341:0042 (Vendor ID 2341, Product ID 0042 for Mega)
+#
+# The rule grants read/write permissions (0666) to the Arduino Mega using the symbolic link /dev/arduino
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0042", MODE="0666", SYMLINK+="arduino"

--- a/udev_rules/README.md
+++ b/udev_rules/README.md
@@ -1,0 +1,47 @@
+# udev_rules
+
+This directory contains udev rules to assign attached hardware to a specific
+device driver.
+
+## Creating a `udev` Rules File
+
+1) Attach your device (i.e. Arduino Mega) to your computer.
+
+2) Run `lsusb`.  Look for an entry with your device:
+```
+Bus 003 Device 002: ID 2341:0042 Arduino SA Mega 2560 R3 (CDC ACM)
+```
+
+We need the vendor and product IDs from this entry.  For the Arduino Mega the
+vendor ID is `2341` and the product ID is `0042`.
+
+3) Add a `udev` rule in `/etc/udev/rules.d`:
+
+```
+sudo vim /etc/udev/rules.d/99-arduino.rules
+```
+
+Within this file add the following:
+```
+SUBSYSTEM=="tty", ATTRS{idVendor}=="<Vendor ID>", ATTRS{idProduct}=="<Product
+ID>", MODE="0666", SYMLINK+="<symbolic name for your device file>"
+```
+
+This entry will create a symbolic link for your device in `/dev/<symbolic
+name>`.  The link will grant read/write permissions to your device (`0666` is
+the file permissions `rw-rw-rw-`).
+
+4) Apply your `udev` rules with:
+```
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+The `udev` rules are applied in numerical order with the number in front of the
+filename.  Higher numbers will be applied last, meaning they take precedence.
+
+## Included `udev` Rules
+
+The following is a list of `udev` rules for the Robomagellan robot:
+1) `99-arduino.rules` - Associates an Arduino Mega to the device file
+`/dev/arduino`.


### PR DESCRIPTION
This commit adds a `udev` rules file `99-arduino.rules` to associate the Arduino Mega with device file `/dev/arduino`.