### PR TITLE
IMU - Adding Simulated IMU

### DIFF
--- a/Useful Info.txt
+++ b/Useful Info.txt
@@ -33,6 +33,7 @@ IMU
 2) Sparkfun u-blox GNSS Arduino Library - https://github.com/sparkfun/SparkFun_u-blox_GNSS_Arduino_Library
 3) Sparkfun GNSS Breakout SAM-M8Q - https://www.sparkfun.com/sparkfun-gps-breakout-chip-antenna-sam-m8q-qwiic.html
 4) Sparkfun MPU-9250 Hookup Guide - https://learn.sparkfun.com/tutorials/mpu-9250-hookup-guide/all
+5) Adding a Simulated IMU to Gazebo - https://gazebosim.org/docs/latest/sensors/
 
 Navigation
 ----------

--- a/ros2_ws/src/robomagellan_description/README.md
+++ b/ros2_ws/src/robomagellan_description/README.md
@@ -26,6 +26,8 @@ The following is a list of the Python launch files and their purpose:
    competition environment.
 
 ## Changelog
+`0.10.0` - Added simulated IMU for Gazebo simulation.
+
 `0.9.0` - `ros2_control.xacro` uses `/dev/arduino` instead of `/dev/ttyUSB0`
 thanks to the `99-arduino.rules` `udev` rules.
 

--- a/ros2_ws/src/robomagellan_description/launch/gazebo.launch.py
+++ b/ros2_ws/src/robomagellan_description/launch/gazebo.launch.py
@@ -68,12 +68,20 @@ def generate_launch_description():
     /clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock maps the Gazebo gz.msgs.Clock
     message to the rosgraph_msgs/msg/Clock topic to allow ROS 2 to receive
     Gazebo simulation time.
+
+    /imu@sensor_msgs/msg/Imu[gz.msgs.IMU maps the Gazebo gz.msgs.IMU message to
+    the sensor_msgs/msg/Imu topic to allow ROS 2 to receive Gazebo simulated IMU
+    data.
     """
     gz_ros2_bridge = Node(
         package="ros_gz_bridge",
         executable="parameter_bridge",
         arguments=[
-            "/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock"
+            "/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock",
+            "/imu@sensor_msgs/msg/Imu[gz.msgs.IMU"
+        ],
+        remappings=[
+            ('/imu', '/imu/out')
         ]
     )
 

--- a/ros2_ws/src/robomagellan_description/package.xml
+++ b/ros2_ws/src/robomagellan_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robomagellan_description</name>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
   <description>Contains the URDF robot description</description>
   <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
   <license>Apache 2.0</license>

--- a/ros2_ws/src/robomagellan_description/urdf/gazebo.xacro
+++ b/ros2_ws/src/robomagellan_description/urdf/gazebo.xacro
@@ -36,5 +36,61 @@
     <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
       <parameters>$(find robomagellan_controller)/config/robomagellan_controllers.yaml</parameters>
     </plugin>
+
+    <!-- Simulated IMU -->
+    <plugin filename="gz-sim-imu-system" name="gz::sim::systems::Imu">
+    </plugin>
+  </gazebo>
+
+  <!-- Simulated IMU parameters -->
+  <gazebo reference="imu_link">
+    <sensor name="imu" type="imu">
+      <always_on>true</always_on>
+      <update_rate>100</update_rate>
+      <gz_frame_id>imu_link</gz_frame_id>
+      <topic>imu</topic>
+      <imu>
+        <angular_velocity>
+          <x>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>2e-4</stddev>
+            </noise>
+          </x>
+          <y>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>2e-4</stddev>
+            </noise>
+          </y>
+          <z>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>2e-4</stddev>
+            </noise>
+          </z>
+        </angular_velocity>
+        <linear_acceleration>
+          <x>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>1.7e-2</stddev>
+            </noise>
+          </x>
+          <y>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>1.7e-2</stddev>
+            </noise>
+          </y>
+          <z>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>1.7e-2</stddev>
+            </noise>
+          </z>
+        </linear_acceleration>
+      </imu>
+    </sensor>
   </gazebo>
 </robot>

--- a/ros2_ws/src/robomagellan_description/urdf/robomagellan.urdf.xacro
+++ b/ros2_ws/src/robomagellan_description/urdf/robomagellan.urdf.xacro
@@ -180,4 +180,38 @@
 
   <xacro:wheel prefix="right" suffix="front" reflectx="1" reflecty="-1" mimic_wheel="false"/>
   <xacro:wheel prefix="right" suffix="rear" reflectx="-1" reflecty="-1" mimic_wheel="true"/>
+
+  <!-- Simulated IMU (centered on robot's origin) -->
+  <link name="imu_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.0005"/>
+
+      <!-- TODO: Need dimensions of IMU -->
+      <inertia ixx="1.46176048428261E-08" ixy="1.40015117949421E-10" ixz="-1.9963387293740E-12" iyy="8.59662482954888E-09" iyz="7.52375112767959E-12" izz="2.30279421279312E-08" />
+    </inertial>
+
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <!-- TODO: Need dimensions of IMU -->
+        <box size="0.001 0.001 0.001"/>
+      </geometry>
+    </visual>
+
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <!-- TODO: Need dimensions of IMU -->
+        <box size="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="imu_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="imu_link"/>
+    <axis xyz="0 0 0"/>
+  </joint>
 </robot>


### PR DESCRIPTION
This commit adds a simulated IMU to the Gazebo robot model.  The IMU data can be viewed by echoing the topic `/imu/out`.