### PR TITLE
udev - Adding Arduino Uno R4 udev Rules

### DIFF
--- a/udev_rules/99-arduino-uno-r4.rules
+++ b/udev_rules/99-arduino-uno-r4.rules
@@ -1,0 +1,8 @@
+# 99-arduino-uno-r4.rules
+#
+# udev rules file for assigning an Arduino Uno R4 to device file /dev/arduino
+#
+# Arduino Mega has ID 2341:1002 (Vendor ID 2341, Product ID 1002 for Mega)
+#
+# The rule grants read/write permissions (0666) to the Arduino Mega using the symbolic link /dev/arduino
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="1002", MODE="0666", SYMLINK+="arduino"

--- a/udev_rules/README.md
+++ b/udev_rules/README.md
@@ -45,3 +45,5 @@ filename.  Higher numbers will be applied last, meaning they take precedence.
 The following is a list of `udev` rules for the Robomagellan robot:
 1) `99-arduino.rules` - Associates an Arduino Mega to the device file
 `/dev/arduino`.
+2) `99-arduino-uno-r4.rules` - Associates an Arduino Uno R4 to the device file
+`/dev/arduino`.


### PR DESCRIPTION
This commit adds in a new `udev` rule for the Arduino Uno R4 for testing purposes since my only Arduino Mega is attached to the real robot.