### PR TITLE
robomagellan_firmware - HW Interface does not send Duplicate Commands

### DIFF
--- a/ros2_ws/src/robomagellan_firmware/README.md
+++ b/ros2_ws/src/robomagellan_firmware/README.md
@@ -26,6 +26,9 @@ The hardware interface plugin is loaded from the robot's URDF
 (`robomagellan.urdf.xacro` within the `robomagellan_description` package).
 
 ## Changelog
+`0.5.0` - `RobomagellanInterface::write()` does not send duplicated motor
+commands.
+
 `0.4.0` - Implemented `RobomagellanInterface::write()` to send desired motor
 elocities to the Arduino.
 

--- a/ros2_ws/src/robomagellan_firmware/include/robomagellan_firmware/robomagellan_interface.hpp
+++ b/ros2_ws/src/robomagellan_firmware/include/robomagellan_firmware/robomagellan_interface.hpp
@@ -12,6 +12,7 @@
 #include <rclcpp_lifecycle/state.hpp>
 #include <rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp>
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -60,6 +61,19 @@ public:
   hardware_interface::return_type write(const rclcpp::Time &, const rclcpp::Duration &) override;
 
 private:
+  /*
+   * Compares whether 2 double-precision values are equal to each.
+   *
+   * Parameters:
+   *   num1, num2 (double): Values to compare
+   *
+   * Returns:
+   *   True if num1 == num2; false otherwise.
+   */
+  bool DoubleEquals(const double num1, const double num2) const {
+    return std::fabs(num1 - num2) <= std::numeric_limits<double>::epsilon();
+  }
+
   // Serial connection to the Arduino
   LibSerial::SerialPort arduino_;
 
@@ -77,6 +91,10 @@ private:
 
   // The last time this interface was run
   rclcpp::Time last_run_;
+
+  // Each wheel's last sent velocities (rad/s)
+  double last_left_cmd_  = std::numeric_limits<double>::max();
+  double last_right_cmd_ = std::numeric_limits<double>::max();
 }; // End class RobomagellanInterface
 
 } // End namespace robomagellan_firmware

--- a/ros2_ws/src/robomagellan_firmware/package.xml
+++ b/ros2_ws/src/robomagellan_firmware/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robomagellan_firmware</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Contains ROS 2 hardware interfaces to the real robot </description>
   <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
   <license>Apache 2.0</license>

--- a/ros2_ws/src/robomagellan_firmware/src/robomagellan_interface.cpp
+++ b/ros2_ws/src/robomagellan_firmware/src/robomagellan_interface.cpp
@@ -184,6 +184,17 @@ hardware_interface::return_type RobomagellanInterface::read(const rclcpp::Time &
 
 hardware_interface::return_type RobomagellanInterface::write(const rclcpp::Time &,
                                                              const rclcpp::Duration &) {
+  // Check if either desired velocity is different than the last sent velocities
+  const bool left_vel_same = DoubleEquals(velocity_commands_[0],
+                                          last_left_cmd_);
+  const bool right_vel_same = DoubleEquals(velocity_commands_[1],
+                                           last_right_cmd_);
+
+  // Don't send the send commands repeatedly
+  if (left_vel_same && right_vel_same) {
+    return hardware_interface::return_type::OK;
+  }
+
   // Write desired motor velocities to the Arduino
   RCLCPP_INFO_STREAM(rclcpp::get_logger("RobomagellanInterface"),
       "Writing velocities: " << velocity_commands_[0] << "; " << velocity_commands_[1]);
@@ -211,6 +222,10 @@ hardware_interface::return_type RobomagellanInterface::write(const rclcpp::Time 
         " to Arduino on port: " << port_);
     return hardware_interface::return_type::ERROR;
   }
+
+  // Update last sent velocities
+  last_left_cmd_  = velocity_commands_[0];
+  last_right_cmd_ = velocity_commands_[1];
 
   return hardware_interface::return_type::OK;
 }


### PR DESCRIPTION
This commit updates `RobomagellanInterface::write()` to not send duplicate desired motor commands.