### PR TITLE
robomagellan_firmware - HW Interface Parses Position/Velocity

### DIFF
--- a/ros2_ws/src/robomagellan_firmware/README.md
+++ b/ros2_ws/src/robomagellan_firmware/README.md
@@ -19,6 +19,9 @@ will provide the desired wheel velocities to these hardware interfaces.
 An Arduino Mega connects to the motor controllers and the quadrature encoders.
 This Arduino is connected to the Raspberry Pi 5 via a USB cable.
 
+The Arduino will send through the Serial connection the motors' position (rad)
+and velocity (rad/s).
+
 ## Launch Files
 
 `hardware_interface.launch.py` launches the `ros2_control` `ControllerManager`.
@@ -26,6 +29,9 @@ The hardware interface plugin is loaded from the robot's URDF
 (`robomagellan.urdf.xacro` within the `robomagellan_description` package).
 
 ## Changelog
+`0.6.0` - `RobomagellanInterface::read()` parses motor positions and velocities
+instead of calculating them.
+
 `0.5.0` - `RobomagellanInterface::write()` does not send duplicated motor
 commands.
 

--- a/ros2_ws/src/robomagellan_firmware/include/robomagellan_firmware/robomagellan_interface.hpp
+++ b/ros2_ws/src/robomagellan_firmware/include/robomagellan_firmware/robomagellan_interface.hpp
@@ -89,9 +89,6 @@ private:
   // Wheel velocities
   std::vector<double> velocity_states_;
 
-  // The last time this interface was run
-  rclcpp::Time last_run_;
-
   // Each wheel's last sent velocities (rad/s)
   double last_left_cmd_  = std::numeric_limits<double>::max();
   double last_right_cmd_ = std::numeric_limits<double>::max();

--- a/ros2_ws/src/robomagellan_firmware/package.xml
+++ b/ros2_ws/src/robomagellan_firmware/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robomagellan_firmware</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Contains ROS 2 hardware interfaces to the real robot </description>
   <maintainer email="rcxking@gmail.com">Bryant Pong</maintainer>
   <license>Apache 2.0</license>

--- a/ros2_ws/src/robomagellan_firmware/src/robomagellan_interface.cpp
+++ b/ros2_ws/src/robomagellan_firmware/src/robomagellan_interface.cpp
@@ -53,8 +53,6 @@ CallbackReturn RobomagellanInterface::on_init(const hardware_interface::Hardware
   position_states_.reserve(info_.joints.size());
   velocity_states_.reserve(info_.joints.size());
 
-  last_run_ = rclcpp::Clock().now();
-
   return CallbackReturn::SUCCESS;
 }
 
@@ -143,41 +141,58 @@ hardware_interface::return_type RobomagellanInterface::read(const rclcpp::Time &
   // Read the wheel velocities from the Arduino
   if (arduino_.IsDataAvailable()) {
     /*
-     * Time delta between now and the previous time read() was called.  Need
-     * this to integrate the wheel velocities to get wheel position.
-     */
-    const double dt = (rclcpp::Clock().now() - last_run_).seconds();
-
-    /*
      * Arduino sends string of the format:
-     * "L<left wheel vel>;R<right wheel vel>;"
+     * "L<left wheel pos (rad)>,<left wheel vel (rad/s)>;R<right wheel pos
+     * (rad)>,<right wheel vel (rad/s)>;"
      */
-    std::string next_vels;
-    arduino_.ReadLine(next_vels);
-    RCLCPP_INFO_STREAM(rclcpp::get_logger("RobomagellanInterface"),
-        "Received next_vels: " << next_vels);
+    std::string next_info;
+    arduino_.ReadLine(next_info);
+    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("RobomagellanInterface"),
+        "Received next_info: " << next_info);
 
-    std::string token;
-    std::stringstream ss(next_vels);
-    while (std::getline(ss, token, ';')) {
-      // First character is L (left) or R (right) motor.  Ignore everything else
-      const char first_char = token[0];
-
-      if (first_char == 'L') {
-        velocity_states_.at(0) = std::stod(token.substr(1, token.size()));
-        position_states_.at(0) += velocity_states_.at(0) * dt;
-      } else if (first_char == 'R') {
-        velocity_states_.at(1) = std::stod(token.substr(1, token.size()));
-        position_states_.at(1) += velocity_states_.at(1) * dt;
-      } else {
-        // ERROR: Unrecognized character
-        RCLCPP_ERROR_STREAM(rclcpp::get_logger("RobomagellanInterface"),
-            "ERROR: Unrecognized first_char: " << first_char);
+    std::string next_motor_info;
+    std::stringstream ss(next_info);
+    while (std::getline(ss, next_motor_info, ';')) {
+      // Ensure next motor information isn't blank
+      if (next_motor_info.empty()) {
+        RCLCPP_ERROR(rclcpp::get_logger("RobomagellanInterface"),
+            "ERROR: next_motor_info is blank!");
+        continue;
       }
-    }
 
-    // Update last time read() was run
-    last_run_ = rclcpp::Clock().now();
+      // First character is L (left) or R (right) motor.  Ignore everything else
+      const char first_char = next_motor_info[0];
+
+      const bool first_char_l = (first_char == 'L');
+      const bool first_char_r = (first_char == 'R');
+
+      if (first_char_l || first_char_r) {
+        // Extract motor position and velocity
+        const std::string motor_info(next_motor_info.substr(1));
+        std::string next_pos_rads, next_vel_rads_per_sec;
+        std::stringstream ss2(motor_info);
+        std::getline(ss2, next_pos_rads, ',');
+        std::getline(ss2, next_vel_rads_per_sec, ',');
+
+        // Ensure valid position/velocity
+        if (next_pos_rads.empty() || next_vel_rads_per_sec.empty()) {
+          RCLCPP_ERROR_STREAM(rclcpp::get_logger("RobomagellanInterface"),
+              "ERROR: Invalid position and/or velocity! next_pos_rads: " <<
+              next_pos_rads << "; next_vel_rads_per_sec: " <<
+              next_vel_rads_per_sec);
+          continue;
+        }
+
+        // Update position and velocity
+        const size_t idx = (first_char_l) ? 0 : 1;
+        position_states_.at(idx) = std::stod(next_pos_rads);
+        velocity_states_.at(idx) = std::stod(next_vel_rads_per_sec);
+
+        RCLCPP_DEBUG_STREAM(rclcpp::get_logger("RobomagellanInterface"),
+            "idx: " << idx << "; next_pos_rads: " << next_pos_rads <<
+            "; next_vel_rads_per_sec: " << next_vel_rads_per_sec);
+      } // End if (first_char_l || first_char_r)
+    } // End while (std::getline(ss, next_motor_info, ';'))
   }
   return hardware_interface::return_type::OK;
 }


### PR DESCRIPTION
This commit updates the `RobomagellanInterface::read()` to correctly parse the motors' position (rad) and velocity (rad/s) as sent by the Arduino Mega via the Serial connection.

Tested on the robot by manually turning the wheels and looking at the `/joint_states` topic.  `cppcheck --enable=all` ran on all C++ files with no warnings/errors.